### PR TITLE
External lo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "eval_type_backport",
     "exceptiongroup>=1.2",
     "typing-extensions",
+    "fastapi>=0.128.8",
+    "uvicorn[standard]>=0.39.0",
 ]
 
 [[project.authors]]

--- a/src/striqt/analysis/lib/io.py
+++ b/src/striqt/analysis/lib/io.py
@@ -262,7 +262,7 @@ class MATNewFileStream(_FileStreamBase):
         path,
         *,
         backend_sample_rate: float,
-        key: str|None = None,
+        key: str | None = None,
         skip_samples=0,
         dtype='complex64',
         loop=False,

--- a/src/striqt/analysis/specs/structs.py
+++ b/src/striqt/analysis/specs/structs.py
@@ -186,7 +186,7 @@ class Cellular5GNRSSBSpectrogram(Analysis, kw_only=True, frozen=True):
     max_block_count: typing.Optional[int] = None
 
     # spectrogram info
-    window: types.WindowType = ('kaiser_by_enbw', 2)
+    window: types.WindowType = 'blackmanharris'
     lo_bandstop: typing.Optional[float] = None
 
     # hard-coded for re-use by PSS/SSS functions

--- a/src/striqt/cli/check_sweep.py
+++ b/src/striqt/cli/check_sweep.py
@@ -29,12 +29,14 @@ def run(yaml_path: str):
     print(f'Opening sensor resources...')
     import sys
 
-    sys.stdout.flush()
+    spec = spec.replace(extensions=spec.extensions.replace(sink='striqt.sensor.sinks.NoSink'))
+
     manager = ss.open_resources(spec, yaml_path, test_only=True)
+
 
     with manager as res:
         assert isinstance(spec.sensor, ss.lib.bindings.SensorBinding)
-        source_id = res['source'].backend.id
+        source_id = res['source'].backend.get_id()
 
         print(f'source_id: {source_id!r}')
 

--- a/src/striqt/cli/check_sweep.py
+++ b/src/striqt/cli/check_sweep.py
@@ -29,10 +29,11 @@ def run(yaml_path: str):
     print(f'Opening sensor resources...')
     import sys
 
-    spec = spec.replace(extensions=spec.extensions.replace(sink='striqt.sensor.sinks.NoSink'))
+    spec = spec.replace(
+        extensions=spec.extensions.replace(sink='striqt.sensor.sinks.NoSink')
+    )
 
     manager = ss.open_resources(spec, yaml_path, test_only=True)
-
 
     with manager as res:
         assert isinstance(spec.sensor, ss.lib.bindings.SensorBinding)

--- a/src/striqt/figures/backend.py
+++ b/src/striqt/figures/backend.py
@@ -160,6 +160,7 @@ class _FakeLock:
 class PlotBackend:
     opts: specs.SharedPlotOptions
     lock: RLock | _FakeLock
+    last_grid: 'xarray.plot.FacetGrid | None' = None
 
     def __init__(
         self,
@@ -188,7 +189,7 @@ class PlotBackend:
         else:
             col = self.opts.col
 
-        return {  # ty: ignore
+        return {
             **kwargs,
             'figsize': mpl.rcParams['figure.figsize'],
             'col_wrap': self.opts.col_wrap,
@@ -344,6 +345,8 @@ class PlotBackend:
             with self.lock:
                 grid.fig.show()
                 plt.close(grid.fig)
+
+        self.last_grid = grid
 
         return path
 

--- a/src/striqt/figures/backend.py
+++ b/src/striqt/figures/backend.py
@@ -168,7 +168,7 @@ def batch_term_images(interactive: typing.Literal['sixel', 'kitcat'] | None):
     image_payload = buffer.getvalue()
 
     if interactive == 'kitcat' or interactive == 'kitty':
-        image_payload = "\033_Ga=d,d=a\033\\\033[H" + image_payload
+        image_payload = '\033_Ga=d,d=a\033\\\033[H' + image_payload
 
     sys.stdout.write(image_payload)
     sys.stdout.flush()

--- a/src/striqt/figures/backend.py
+++ b/src/striqt/figures/backend.py
@@ -160,8 +160,17 @@ class _FakeLock:
         pass
 
 
-def _replace_kitty_images(image_payload=''):
-    sys.stdout.write("\033_Ga=d,d=a\033\\\033[H" + image_payload)
+@contextlib.contextmanager
+def batch_term_images(interactive: typing.Literal['sixel', 'kitcat'] | None):
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        yield
+    image_payload = buffer.getvalue()
+
+    if interactive == 'kitcat' or interactive == 'kitty':
+        image_payload = "\033_Ga=d,d=a\033\\\033[H" + image_payload
+
+    sys.stdout.write(image_payload)
     sys.stdout.flush()
 
 
@@ -351,18 +360,8 @@ class PlotBackend:
             plt.ion()
         elif self.interactive:
             with self.lock:
-
-                buffer = io.StringIO()
-                with contextlib.redirect_stdout(buffer):
-                    grid.fig.show()  # nab the contextlib output
-                image_payload = buffer.getvalue()
+                grid.fig.show()  # nab the contextlib output
                 plt.close(grid.fig)
-                
-                if self.interactive == 'kitty':
-                    _replace_kitty_images(image_payload)
-                else:
-                    sys.stdout.write(image_payload)
-                    sys.stdout.flush()
 
         self.last_grid = grid
 

--- a/src/striqt/figures/backend.py
+++ b/src/striqt/figures/backend.py
@@ -9,6 +9,7 @@ from . import specs, util
 
 import striqt.analysis as sa
 import striqt.waveform as sw
+import sys
 
 if typing.TYPE_CHECKING:
     from typing_extensions import NotRequired, Unpack
@@ -155,6 +156,12 @@ class _FakeLock:
 
     def __exit__(self, *args):
         pass
+
+
+def _clear_kitty_images():
+    # sys.stdout.write('\033[H')
+    sys.stdout.write("\033_Ga=d,d=a\033\\\033[H")
+    sys.stdout.flush()
 
 
 class PlotBackend:
@@ -343,6 +350,8 @@ class PlotBackend:
             plt.ion()
         elif self.interactive:
             with self.lock:
+                if self.interactive == 'kitty':
+                    _clear_kitty_images()
                 grid.fig.show()
                 plt.close(grid.fig)
 

--- a/src/striqt/figures/backend.py
+++ b/src/striqt/figures/backend.py
@@ -1,6 +1,9 @@
 from __future__ import annotations as __
+import contextlib
 import functools
+import io
 from pathlib import Path
+import sys
 import typing
 
 from multiprocessing import RLock
@@ -9,7 +12,6 @@ from . import specs, util
 
 import striqt.analysis as sa
 import striqt.waveform as sw
-import sys
 
 if typing.TYPE_CHECKING:
     from typing_extensions import NotRequired, Unpack
@@ -158,9 +160,8 @@ class _FakeLock:
         pass
 
 
-def _clear_kitty_images():
-    # sys.stdout.write('\033[H')
-    sys.stdout.write("\033_Ga=d,d=a\033\\\033[H")
+def _replace_kitty_images(image_payload=''):
+    sys.stdout.write("\033_Ga=d,d=a\033\\\033[H" + image_payload)
     sys.stdout.flush()
 
 
@@ -350,10 +351,18 @@ class PlotBackend:
             plt.ion()
         elif self.interactive:
             with self.lock:
-                if self.interactive == 'kitty':
-                    _clear_kitty_images()
-                grid.fig.show()
+
+                buffer = io.StringIO()
+                with contextlib.redirect_stdout(buffer):
+                    grid.fig.show()  # nab the contextlib output
+                image_payload = buffer.getvalue()
                 plt.close(grid.fig)
+                
+                if self.interactive == 'kitty':
+                    _replace_kitty_images(image_payload)
+                else:
+                    sys.stdout.write(image_payload)
+                    sys.stdout.flush()
 
         self.last_grid = grid
 

--- a/src/striqt/figures/labels.py
+++ b/src/striqt/figures/labels.py
@@ -100,6 +100,8 @@ def _coords_to_dicts(
                     d[k] = d[k].title()
             elif np.issubdtype(dtype, np.bool):
                 d[k] = str(v.item())
+            elif v is None:
+                pass
             else:
                 sa.util.get_logger('analysis').warning(
                     f'unhandled type for coord {k!r}'

--- a/src/striqt/sensor/lib/calibration.py
+++ b/src/striqt/sensor/lib/calibration.py
@@ -154,7 +154,6 @@ class YFactorSink(sinks.SinkBase):
         assert isinstance(capture_result.extra_coords, specs.SoapyAcquisitionInfo)
 
         if len(self._pending_data) == self._batch.size:
-            self.flush()
             self._batch.next()
 
         return ret

--- a/src/striqt/sensor/lib/calibration.py
+++ b/src/striqt/sensor/lib/calibration.py
@@ -172,7 +172,7 @@ class YFactorSink(sinks.SinkBase):
 
         loops = data[0].attrs['loops']
         implied_loops = (data[0].attrs['calibration'] or {}).get('implied_loops', [])
-        fields = implied_loops + [l['field'] for l in loops if l['field'] is not None]
+        fields = list(implied_loops) + [l['field'] for l in loops if l['field'] is not None]
         if 'sample_rate' in fields:
             i = fields.index('sample_rate')
             fields[i] = 'backend_sample_rate'

--- a/src/striqt/sensor/lib/calibration.py
+++ b/src/striqt/sensor/lib/calibration.py
@@ -154,15 +154,11 @@ class YFactorSink(sinks.SinkBase):
         assert isinstance(capture_result.extra_coords, specs.SoapyAcquisitionInfo)
 
         if len(self._pending_data) == self._batch.size:
-            # self.flush()
             self._batch.next()
+        if self.captures_elapsed == self._batch.total_size:
+            self.flush()
 
         return ret
-
-    def close(self, *exc_info):
-        if exc_info == (None, None, None):
-            self.flush()
-        super().close(*exc_info)
 
     def flush(self):
         data = self.pop()

--- a/src/striqt/sensor/lib/calibration.py
+++ b/src/striqt/sensor/lib/calibration.py
@@ -153,8 +153,7 @@ class YFactorSink(sinks.SinkBase):
 
         assert isinstance(capture_result.extra_coords, specs.SoapyAcquisitionInfo)
 
-        if len(self._pending_data) == self._batch.size:
-            self._batch.next()
+        self.captures_elapsed += 1
         if self.captures_elapsed == self._batch.total_size:
             self.flush()
 

--- a/src/striqt/sensor/lib/calibration.py
+++ b/src/striqt/sensor/lib/calibration.py
@@ -171,7 +171,8 @@ class YFactorSink(sinks.SinkBase):
         port = int(data[0].port)
 
         loops = data[0].attrs['loops']
-        fields = [l['field'] for l in loops if l['field'] is not None]
+        implied_loops = (data[0].attrs['calibration'] or {}).get('implied_loops', [])
+        fields = implied_loops + [l['field'] for l in loops if l['field'] is not None]
         if 'sample_rate' in fields:
             i = fields.index('sample_rate')
             fields[i] = 'backend_sample_rate'

--- a/src/striqt/sensor/lib/calibration.py
+++ b/src/striqt/sensor/lib/calibration.py
@@ -154,9 +154,15 @@ class YFactorSink(sinks.SinkBase):
         assert isinstance(capture_result.extra_coords, specs.SoapyAcquisitionInfo)
 
         if len(self._pending_data) == self._batch.size:
+            # self.flush()
             self._batch.next()
 
         return ret
+
+    def close(self, *exc_info):
+        if exc_info == (None, None, None):
+            self.flush()
+        super().close(*exc_info)
 
     def flush(self):
         data = self.pop()

--- a/src/striqt/sensor/lib/calibration.py
+++ b/src/striqt/sensor/lib/calibration.py
@@ -172,7 +172,9 @@ class YFactorSink(sinks.SinkBase):
 
         loops = data[0].attrs['loops']
         implied_loops = (data[0].attrs['calibration'] or {}).get('implied_loops', [])
-        fields = list(implied_loops) + [l['field'] for l in loops if l['field'] is not None]
+        fields = list(implied_loops) + [
+            l['field'] for l in loops if l['field'] is not None
+        ]
         if 'sample_rate' in fields:
             i = fields.index('sample_rate')
             fields[i] = 'backend_sample_rate'

--- a/src/striqt/sensor/lib/compute/corrections.py
+++ b/src/striqt/sensor/lib/compute/corrections.py
@@ -260,7 +260,6 @@ def _apply_conj(
 ) -> Array:
     assert isinstance(do_conj, tuple)
     xp = sw.array_namespace(x)
-    hot_inds = [bool(b) for b in do_conj]
 
     if not any(do_conj):
         return x

--- a/src/striqt/sensor/lib/compute/corrections.py
+++ b/src/striqt/sensor/lib/compute/corrections.py
@@ -47,6 +47,9 @@ def correct_iq(
     capture = iq.capture
     xp = sw.array_namespace(x)
 
+    if iq.conjugate:
+        _apply_conj(x, iq.conjugate, overwrite_x=overwrite_x)
+
     if not isinstance(capture, specs.SensorCapture):
         raise TypeError('iq.capture must be a capture specification')
 
@@ -250,6 +253,19 @@ def _apply_trigger_shifts(x: Array, shifts: Array, size_out: int) -> Array:
         for i in range(x.shape[0]):
             out[i, :] = x[i, shifts[i] : shifts[i] + size_out]
         return out
+
+
+def _apply_conj(x: Array, do_conj: tuple[bool|None, ...], overwrite_x: bool = False) -> Array:
+    assert isinstance(do_conj, tuple)
+    xp = sw.array_namespace(x)
+    hot_inds = [bool(b) for b in do_conj]
+
+    if not any(hot_inds):
+        return x
+
+    sub = sw.axis_index(x, hot_inds, axis=-2)
+
+    return xp.conj(sub, out=sub if overwrite_x else None)
 
 
 def _scale_only(

--- a/src/striqt/sensor/lib/compute/corrections.py
+++ b/src/striqt/sensor/lib/compute/corrections.py
@@ -47,9 +47,6 @@ def correct_iq(
     capture = iq.capture
     xp = sw.array_namespace(x)
 
-    if iq.conjugate:
-        _apply_conj(x, iq.conjugate, overwrite_x=overwrite_x)
-
     if not isinstance(capture, specs.SensorCapture):
         raise TypeError('iq.capture must be a capture specification')
 
@@ -63,6 +60,9 @@ def correct_iq(
         needs_filter = False
     else:
         x_pre_filter, offs = _resample(iq, **resample_kws)
+
+    if iq.conjugate:
+        x_pre_filter = _apply_conj(x_pre_filter, iq.conjugate, overwrite_x=True)
 
     # apply the filter here and ensure we're working with a copy if needed
     if needs_filter:
@@ -255,17 +255,28 @@ def _apply_trigger_shifts(x: Array, shifts: Array, size_out: int) -> Array:
         return out
 
 
-def _apply_conj(x: Array, do_conj: tuple[bool|None, ...], overwrite_x: bool = False) -> Array:
+def _apply_conj(
+    x: Array, do_conj: tuple[bool | None, ...], overwrite_x: bool = False
+) -> Array:
     assert isinstance(do_conj, tuple)
     xp = sw.array_namespace(x)
     hot_inds = [bool(b) for b in do_conj]
 
-    if not any(hot_inds):
+    if not any(do_conj):
         return x
+    if len(do_conj) != x.shape[-2]:
+        raise ValueError(
+            'conjugate size mismatch in internal API: this should never happen'
+        )
+    if not overwrite_x:
+        x = x.copy()
 
-    sub = sw.axis_index(x, hot_inds, axis=-2)
+    for port, port_conj in enumerate(do_conj):
+        if port_conj:
+            sub = x[..., port, :]
+            xp.conj(sub, out=sub)
 
-    return xp.conj(sub, out=sub if overwrite_x else None)
+    return x
 
 
 def _scale_only(

--- a/src/striqt/sensor/lib/compute/datasets.py
+++ b/src/striqt/sensor/lib/compute/datasets.py
@@ -312,6 +312,9 @@ def _coords_template(
                 continue
             coord_vars[field.name] = make_var(field)
 
+    # TODO: remove this hardcoded bolt-on fix
+    coord_vars.pop('signal_trigger', None)
+
     # templates for analysis loops
     for loop in loops:
         if loop.isin != 'analysis':

--- a/src/striqt/sensor/lib/sinks.py
+++ b/src/striqt/sensor/lib/sinks.py
@@ -22,9 +22,11 @@ else:
 
 class _BatchTracker:
     size: int
+    total_size: int
 
     def __init__(self, captures: tuple[specs.SensorCapture, ...], min_size: int):
         sizes = specs.helpers.concat_group_sizes(captures, min_size=min_size)
+        self.total_size = sum(sizes)
 
         self._cycler = itertools.cycle(sizes)
         if len(sizes) > 0 and sizes[0] > 0:

--- a/src/striqt/sensor/lib/sources/soapy.py
+++ b/src/striqt/sensor/lib/sources/soapy.py
@@ -675,7 +675,8 @@ class SoapySource(SourceBackend[SS, specs.SoapyCapture]):
         # gain before center frequency to accommodate attenuator settling time
         for c in specs.helpers.split_capture_ports(capture):
             assert not isinstance(c.center_frequency, tuple)
-            freq = c.center_frequency - rs['lo_offset']
+            lo_freq = c.external_lo_frequency or 0
+            freq = abs(lo_freq - (c.center_frequency - rs['lo_offset']))
             self.device.setGain(SoapySDR.SOAPY_SDR_RX, c.port, c.gain)
             self.device.setFrequency(SoapySDR.SOAPY_SDR_RX, c.port, freq)
             self.device.setSampleRate(SoapySDR.SOAPY_SDR_RX, c.port, rs['fs_sdr'])

--- a/src/striqt/sensor/lib/sources/soapy.py
+++ b/src/striqt/sensor/lib/sources/soapy.py
@@ -675,13 +675,13 @@ class SoapySource(SourceBackend[SS, specs.SoapyCapture]):
         # gain before center frequency to accommodate attenuator settling time
         for c in specs.helpers.split_capture_ports(capture):
             assert not isinstance(c.center_frequency, tuple)
-            lo_freq = c.external_lo_frequency or 0.
+            lo_freq = c.external_lo_frequency or 0.0
             assert isinstance(lo_freq, float)
             freq = abs(lo_freq - (c.center_frequency - rs['lo_offset']))
             self.device.setGain(SoapySDR.SOAPY_SDR_RX, c.port, c.gain)
             self.device.setFrequency(SoapySDR.SOAPY_SDR_RX, c.port, freq)
             self.device.setSampleRate(SoapySDR.SOAPY_SDR_RX, c.port, rs['fs_sdr'])
-        
+
         return capture
 
     def get_resampler(self, capture: specs.SoapyCapture) -> sw.ResamplerDesign:
@@ -764,7 +764,7 @@ class SoapySource(SourceBackend[SS, specs.SoapyCapture]):
         # flag conjugating the IQ for any high_side LOs
         conj = []
         for c in specs.helpers.split_capture_ports(capture):
-            lo_freq = c.external_lo_frequency or 0.
+            lo_freq = c.external_lo_frequency or 0.0
             assert isinstance(c.center_frequency, float) and isinstance(lo_freq, float)
             diff = lo_freq - (c.center_frequency - rs['lo_offset'])
             conj.append(diff > 0)

--- a/src/striqt/sensor/lib/sources/soapy.py
+++ b/src/striqt/sensor/lib/sources/soapy.py
@@ -675,11 +675,13 @@ class SoapySource(SourceBackend[SS, specs.SoapyCapture]):
         # gain before center frequency to accommodate attenuator settling time
         for c in specs.helpers.split_capture_ports(capture):
             assert not isinstance(c.center_frequency, tuple)
-            lo_freq = c.external_lo_frequency or 0
+            lo_freq = c.external_lo_frequency or 0.
+            assert isinstance(lo_freq, float)
             freq = abs(lo_freq - (c.center_frequency - rs['lo_offset']))
             self.device.setGain(SoapySDR.SOAPY_SDR_RX, c.port, c.gain)
             self.device.setFrequency(SoapySDR.SOAPY_SDR_RX, c.port, freq)
             self.device.setSampleRate(SoapySDR.SOAPY_SDR_RX, c.port, rs['fs_sdr'])
+        
         return capture
 
     def get_resampler(self, capture: specs.SoapyCapture) -> sw.ResamplerDesign:
@@ -756,5 +758,16 @@ class SoapySource(SourceBackend[SS, specs.SoapyCapture]):
         iq.extra_data.update(compute_overload_info(samples, self.spec, capture))
         iq.extra_data.update(self.read_peripherals())
         _assign_iq_calibration(iq)
+
+        rs = self.get_resampler(capture)
+
+        # flag conjugating the IQ for any high_side LOs
+        conj = []
+        for c in specs.helpers.split_capture_ports(capture):
+            lo_freq = c.external_lo_frequency or 0.
+            assert isinstance(c.center_frequency, float) and isinstance(lo_freq, float)
+            diff = lo_freq - (c.center_frequency - rs['lo_offset'])
+            conj.append(diff > 0)
+        iq.conjugate = tuple(conj)
 
         return iq

--- a/src/striqt/sensor/specs/dataclasses.py
+++ b/src/striqt/sensor/specs/dataclasses.py
@@ -35,3 +35,6 @@ class AcquiredIQ(sa.dataarrays.AcquiredIQ):
     resampler: sw.ResamplerDesign
     format_path: helpers.PathFormatter | None = None
     voltage_scale: sw.typing.Array | float = 1
+
+    # whether to evaluate the complex conjugate of each port
+    conjugate: tuple[bool, ...] | False = False

--- a/src/striqt/sensor/specs/structs.py
+++ b/src/striqt/sensor/specs/structs.py
@@ -51,6 +51,7 @@ class SensorCapture(Capture, frozen=True, kw_only=True):
     host_resample: bool = True
     backend_sample_rate: Optional[types.BackendSampleRate] = None
     adjust_analysis: types.AnalysisAdjustments = msgspec.field(default_factory=dict)
+    external_lo_frequency: types.LOFrequency = None
 
 
 class SoapyCapture(SensorCapture, frozen=True, kw_only=True):

--- a/src/striqt/sensor/specs/structs.py
+++ b/src/striqt/sensor/specs/structs.py
@@ -197,12 +197,12 @@ class SharedPlotOptions(
     SpecBase, frozen=True, kw_only=True, forbid_unknown_fields=True
 ):
     # further validation in striqt.figures.specs subclass
-    style: str | None = None
-    col: str | None = 'port'
-    row: str | None = None
+    style: Union[str, None] = None
+    col: Union[str, None] = 'port'
+    row: Union[str, None] = None
     col_label_format: str = 'Port {port}'
-    row_label_format: str | None = None
-    col_wrap: int | None = None
+    row_label_format: Union[str, None] = None
+    col_wrap: Union[int, None] = None
     suptitle_fmt: str = '{start_time}'
     filename_fmt: str = '{name} {start_time}.svg'
 
@@ -211,7 +211,7 @@ class DataOptions(SpecBase, frozen=True, kw_only=True, forbid_unknown_fields=Tru
     # further validation in striqt.figures.specs subclass
     groupby_dims: tuple[str, ...] = ()
     sweep_index: int
-    query: str | None = None
+    query: Union[str, None] = None
     select: dict[str, Any] = msgspec.field(default_factory=dict)
 
 
@@ -495,7 +495,7 @@ class AcquisitionInfo(msgspec.Struct, kw_only=True, frozen=True):
     source_id: types.SourceID = ''
     sweep_index: Union[int, None] = None
     capture_index: int = 0
-    signal_trigger: sa.Trigger | None = None
+    signal_trigger: Union[sa.Trigger, None] = None
 
     def replace(self, **attrs) -> _Self:
         """returns a copy of self with changed attributes.
@@ -521,8 +521,8 @@ class AcquisitionInfo(msgspec.Struct, kw_only=True, frozen=True):
 class SoapyAcquisitionInfo(AcquisitionInfo, kw_only=True, frozen=True):
     """extra coordinate information returned from an acquisition"""
 
-    sweep_start_time: types.SweepStartTime | None = None
-    start_time: types.StartTime | None
+    sweep_start_time: Union[types.SweepStartTime, None] = None
+    start_time: Union[types.StartTime, None]
     backend_sample_rate: Optional[types.BackendSampleRate]
     source_id: types.SourceID = ''
 

--- a/src/striqt/sensor/specs/structs.py
+++ b/src/striqt/sensor/specs/structs.py
@@ -300,6 +300,7 @@ class NoPeripherals(Peripherals, frozen=True, kw_only=True):
 class ManualYFactorPeripheral(Peripherals, frozen=True, kw_only=True):
     enr: types.ENR
     ambient_temperature: types.AmbientTemperature
+    implied_loops: tuple[str, ...] = ()
 
 
 # %% Top-level Sweep specifications
@@ -469,7 +470,8 @@ class CalibrationSweep(
     def __post_init__(self):
         super().__post_init__()
 
-        if not self.calibration.implied_loops and len(self.captures) > 1:
+        implied_loops = getattr(self.calibration, 'implied_loops', ())
+        if len(self.captures) > 1 and not implied_loops:
             raise TypeError(
                 'calibration sweeps may only include explicit capture sequences if implied_loops are specified'
             )

--- a/src/striqt/sensor/specs/structs.py
+++ b/src/striqt/sensor/specs/structs.py
@@ -495,7 +495,10 @@ class AcquisitionInfo(msgspec.Struct, kw_only=True, frozen=True):
     source_id: types.SourceID = ''
     sweep_index: Union[int, None] = None
     capture_index: int = 0
-    signal_trigger: Union[sa.Trigger, None] = None
+
+    # TODO: this is wrong. want sa.Trigger, but that is triggering a type
+    # resolution problem in py39
+    signal_trigger: Union[str, None] = None
 
     def replace(self, **attrs) -> _Self:
         """returns a copy of self with changed attributes.

--- a/src/striqt/sensor/specs/structs.py
+++ b/src/striqt/sensor/specs/structs.py
@@ -469,9 +469,9 @@ class CalibrationSweep(
     def __post_init__(self):
         super().__post_init__()
 
-        if len(self.captures) > 1:
+        if not self.calibration.implied_loops and len(self.captures) > 1:
             raise TypeError(
-                'calibration sweeps may specify loops but not captures, only loops'
+                'calibration sweeps may only include explicit capture sequences if implied_loops are specified'
             )
         if self.source.calibration is not None:
             raise ValueError('source.calibration must be None for a calibration sweep')

--- a/src/striqt/sensor/specs/structs.py
+++ b/src/striqt/sensor/specs/structs.py
@@ -147,9 +147,7 @@ class SoapySource(Source, frozen=True, kw_only=True):
             pass
         elif self.signal_trigger not in registry.signal_trigger:
             registered = set(registry.signal_trigger)
-            raise ValueError(
-                f'signal_trigger "{self.signal_trigger!r}" is not one of the registered functions {registered!r}'
-            )
+            raise ValueError(f'signal_trigger must be one of {registered!r}')
 
 
 class FunctionSource(Source, kw_only=True, frozen=True):
@@ -171,7 +169,7 @@ class MATSource(Source, kw_only=True, frozen=True):
     file_metadata: Union[types.FileMetadata, None] = None
     loop: types.FileLoop = False
     transport_dtype: ClassVar[types.TransportDType] = 'complex64'
-    key: Union[str,None] = None
+    key: Union[str, None] = None
 
 
 class TDMSSource(Source, frozen=True, kw_only=True):

--- a/src/striqt/sensor/specs/types.py
+++ b/src/striqt/sensor/specs/types.py
@@ -79,6 +79,10 @@ GaplessRepeat = Annotated[
     bool,
     Meta('whether to raise an exception on overflows between identical captures'),
 ]
+ImpliedLoops = Annotated[
+    tuple[str, ...], Meta(standard_name='List of looped fields embedded in the capture list')
+]
+
 IsIn = Annotated[
     Literal['capture', 'analysis'],
     Meta('selects whether to loop a capture or analysis parameters'),

--- a/src/striqt/sensor/specs/types.py
+++ b/src/striqt/sensor/specs/types.py
@@ -84,7 +84,8 @@ IsIn = Annotated[
     Meta('selects whether to loop a capture or analysis parameters'),
 ]
 LOFrequency = Annotated[
-    Union[float, None], Meta('LO frequency of external frequency converter')
+    Union[float, None, tuple[Union[float, None], ...]],
+    Meta('LO frequency of external frequency converter'),
 ]
 LOShift = Annotated[Literal['left', 'right', 'none'], Meta('LO shift direction')]
 MockSensor = Annotated[

--- a/src/striqt/sensor/specs/types.py
+++ b/src/striqt/sensor/specs/types.py
@@ -83,6 +83,7 @@ IsIn = Annotated[
     Literal['capture', 'analysis'],
     Meta('selects whether to loop a capture or analysis parameters'),
 ]
+LOFrequency = Annotated[Union[float, None], Meta('LO frequency of external frequency converter')]
 LOShift = Annotated[Literal['left', 'right', 'none'], Meta('LO shift direction')]
 MockSensor = Annotated[
     Optional[str],

--- a/src/striqt/sensor/specs/types.py
+++ b/src/striqt/sensor/specs/types.py
@@ -83,7 +83,9 @@ IsIn = Annotated[
     Literal['capture', 'analysis'],
     Meta('selects whether to loop a capture or analysis parameters'),
 ]
-LOFrequency = Annotated[Union[float, None], Meta('LO frequency of external frequency converter')]
+LOFrequency = Annotated[
+    Union[float, None], Meta('LO frequency of external frequency converter')
+]
 LOShift = Annotated[Literal['left', 'right', 'none'], Meta('LO shift direction')]
 MockSensor = Annotated[
     Optional[str],

--- a/src/striqt/sensor/specs/types.py
+++ b/src/striqt/sensor/specs/types.py
@@ -84,7 +84,7 @@ IsIn = Annotated[
     Meta('selects whether to loop a capture or analysis parameters'),
 ]
 LOFrequencyScalar = Annotated[
-    Union[float, None, tuple[Union[float, None], ...]],
+    Union[float, None],
     Meta('LO frequency of external frequency converter'),
 ]
 LOFrequency = Annotated[

--- a/src/striqt/sensor/specs/types.py
+++ b/src/striqt/sensor/specs/types.py
@@ -83,8 +83,12 @@ IsIn = Annotated[
     Literal['capture', 'analysis'],
     Meta('selects whether to loop a capture or analysis parameters'),
 ]
-LOFrequency = Annotated[
+LOFrequencyScalar = Annotated[
     Union[float, None, tuple[Union[float, None], ...]],
+    Meta('LO frequency of external frequency converter'),
+]
+LOFrequency = Annotated[
+    Union[LOFrequencyScalar, tuple[LOFrequencyScalar, ...]],
     Meta('LO frequency of external frequency converter'),
 ]
 LOShift = Annotated[Literal['left', 'right', 'none'], Meta('LO shift direction')]

--- a/src/striqt/sensor/specs/types.py
+++ b/src/striqt/sensor/specs/types.py
@@ -80,7 +80,8 @@ GaplessRepeat = Annotated[
     Meta('whether to raise an exception on overflows between identical captures'),
 ]
 ImpliedLoops = Annotated[
-    tuple[str, ...], Meta(standard_name='List of looped fields embedded in the capture list')
+    tuple[str, ...],
+    Meta(standard_name='List of looped fields embedded in the capture list'),
 ]
 
 IsIn = Annotated[

--- a/src/striqt/waveform/lib/ofdm.py
+++ b/src/striqt/waveform/lib/ofdm.py
@@ -391,6 +391,9 @@ def index_pss_symbols(
     else:
         raise TypeError('symbol_index has valid type')
 
+    if isinstance(center_frequency, tuple):
+        center_frequency = max(center_frequency)
+
     if symbol_indexes == 'auto':
         if isclose(subcarrier_spacing, 15e3):
             case = 'a'

--- a/tests/sweeps/cellular-sparse-cpu.yaml
+++ b/tests/sweeps/cellular-sparse-cpu.yaml
@@ -11,12 +11,13 @@ source:
   loop: true
   trigger_strobe: 10e-3
   array_backend: "numpy"
+  key: "waveform"
   # skip this in order to evaluate start time offset
   # signal_trigger: "cellular_5g_pss_sync"
 
 loops:
   - kind: repeat
-    count: 1
+    count: 10
 
 captures:
   - sample_rate: 107.52e6 # Hz
@@ -29,6 +30,7 @@ captures:
     #   guard_bandwidths: [875e3, 575e3]
     #   frame_slots: "dddsuudddddddsuudddd"
     #   special_symbols: "ddddddfffffffu"
+
 analysis:
   spectrogram: &spectrogram
     frequency_resolution: 15000 # SCS/2


### PR DESCRIPTION
This implements support for use of external downconverters. After this change, the input center_frequency may be set to the actual RF center frequency. A new optional `external_lo_frequency` capture field was added to `SoapyCapture`; the radio center frequency is then set to an IF frequency determined by `external_lo_frequency` and `center_frequency`. If `external_lo_frequency` is greater than `center_frequency` on a given port, then the baseband waveform is conjugated in order to correct the spectral mirroring.